### PR TITLE
Type casting removed from createPlaylist

### DIFF
--- a/bc-mapi.php
+++ b/bc-mapi.php
@@ -549,7 +549,7 @@ class BCMAPI
 			{
 				foreach($media['videoIds'] as $key => $value)
 				{
-					$media['videoIds'][$key] = (int)$value;
+					$media['videoIds'][$key] = $value;
 				}
 			}
 


### PR DESCRIPTION
Type casting to integer in createPlaylist function causing overflow in 32 bit system. I've removed the type cast operator. 

cheers
hairqles