### PR TITLE
added createCaptions method

### DIFF
--- a/bc-mapi.php
+++ b/bc-mapi.php
@@ -630,6 +630,42 @@ class BCMAPI
 		return $this->putData($request)->result;
 	}
 
+        /**
+         * Uploads/sets a Closed Caption object to Brightcove.
+         * @access Public
+         * @param array [$meta] the metadata for the CaptionSource you want to create. 
+         * @param int [$id] The ID of the video asset to assign the captions to
+         * @param string [$ref_id] The reference ID of the video asset to assign the caption to
+         * TODO:@param string [$file] The location of the file to upload optional
+         * TODO:@param int [$maxsize] The maximum size of the filea
+         * TODO:@param string [$file_checksum] - optional
+         */
+        public function createCaptions($meta, $id = NULL, $ref_id = NULL, $file = NULL)
+        {
+                $request = array();
+                $post = array();
+                $params = array();
+                $media = array();
+
+                // the caption source object is "a JSON object of name/value pairs, each of which corresponds to a settable property of the Video object." 
+                $params['caption_source'] = $meta;
+
+                $params['token'] = $this->token_write;
+                if(isset($id)) {
+                  $params['video_id'] = $id;
+                } elseif(isset($ref_id)) {
+                  $params['video_reference_type'] = $ref_id;
+		} else {
+			throw new BCMAPIIdNotProvided($this, self::ERROR_ID_NOT_PROVIDED);
+		}
+
+                $post['method'] = 'add_captioning';
+                $post['params'] = $params;
+                $request['json'] = json_encode($post) . "\n";
+                return $this->putData($request)->result;
+}
+
+
 	/**
 	 * Uploads a logo overlay file to Brightcove.
 	 * @access Public


### PR DESCRIPTION
Hi, in light of the new Brightcove closed captioning functionality in the Media API, I added an appropriate method in the PHP wrapper that I thought you might want to pull in.
(in fact, a brightcove person on the BC community forum suggested it.)

So far this just handles remote-hosted captions, not uploading
xml directly to BC.

example use (from a Drupal implementation) would be:

``` php
              //  set the closed-caption XML file url, if there is one.
              if($cc_xml_path = $node->field_cc_xml[0]['filepath']) {
               $cc_xml_url = "$base_url/$cc_xml_path";
               // $cc_xml_url = "http://mun2.tv/$cc_xml_path";   // for now., testing
               $caption_source = array( 'displayName' => "caption for " . $node->title,
                                        'url' => $cc_xml_url,
                                        );
               try {
                 $response = $bc->createCaptions($caption_source, $id = $meta['id']);
               } catch (Exception $error) {
                 drupal_set_message('Brightcove Error: Unable to set closed captions: ' . $error);
               }
              }
```

reference:  
http://forum.brightcove.com/t5/Media-APIs/adding-Closed-Captions-via-Media-API/m-p/21306

thanks,

steev
