### PR TITLE
Allow CURLFile

### DIFF
--- a/bc-mapi.php
+++ b/bc-mapi.php
@@ -573,7 +573,7 @@ class BCMAPI
 	 * @access Public
 	 * @since 0.3.4
 	 * @param string [$type] The type of object to upload image for
-	 * @param string [$file] The location of the temporary file
+	 * @param mixed [$file] The location of the temporary file or a CURLFile object
 	 * @param array [$meta] The image information
 	 * @param int [$id] The ID of the media asset to assign the image to
 	 * @param string [$ref_id] The reference ID of the media asset to assign the image to

--- a/bc-mapi.php
+++ b/bc-mapi.php
@@ -624,7 +624,7 @@ class BCMAPI
 
 		if(isset($file))
 		{
-			$request['file'] = '@' . $file;
+			$request['file'] = is_string($file) ? '@' . $file : $file;
 		}
 
 		return $this->putData($request)->result;


### PR DESCRIPTION
While trying to use the `createImage()` method with PHP 5.5.9, I kept getting the error **upload requires a multipart/form-data POST with a valid filestream** when using the doc's examples in trying to upload a thumbnail image.

When I made my own cURL request, I discovered the issue is that newer PHP does not just consider the "old school" method of prefixing the '@' to the full path of a file to be "deprecated", it would appear it is no longer supported. I was only able to successfully upload images after I used the [CURLFile class](http://us2.php.net/manual/en/class.curlfile.php), which is mentioned in the CURLOPT_POSTFIELDS section of [their cURL doc](http://us1.php.net/manual/en/function.curl-setopt.php).

This little change simply makes sure string concatenation only happens on a string, since PHP 5.5 and up users will want this to be a CURLFile object instead.