### PR TITLE
Add option to use HTTP proxy for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,10 @@ The constructor for the BCMAPI class.
 
 	Type:		Integer
 			
+- **proxy** *Public - HTTP Proxy to use for connecting to Brightcove services.*
+
+	Type:		String
+
 - **secure** *Private - Whether BCMAPI is operating over HTTPS*
 
 	Type:		Boolean

--- a/bc-mapi.php
+++ b/bc-mapi.php
@@ -65,6 +65,7 @@ class BCMAPI
 	private $api_calls = 0;
 	private $bit32 = FALSE;
 	private $media_delivery = 'default';
+	private $proxy = NULL;
 	private $secure = FALSE;
 	private $show_notices = FALSE;
 	private $timeout_attempts = 100;
@@ -1357,6 +1358,10 @@ class BCMAPI
 			curl_setopt($curl, CURLOPT_URL, $this->getUrl('write'));
 			curl_setopt($curl, CURLOPT_POST, 1);
 			curl_setopt($curl, CURLOPT_POSTFIELDS, $request);
+		}
+		if(!is_null($this->proxy))
+		{
+			curl_setopt($curl, CURLOPT_PROXY, $this->proxy);
 		}
 
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);


### PR DESCRIPTION
In some environments using an HTTP proxy might be necessary to connect to Brightcove servers. This allows specifying a proxy server to use for curl requests.
