### PR TITLE
Adding PHP 5.5+ compatibility for the createMedia function

### DIFF
--- a/bc-mapi.php
+++ b/bc-mapi.php
@@ -517,7 +517,13 @@ class BCMAPI
 
 		if(isset($file))
 		{
-			$request['file'] = '@' . $file;
+			// Added for PHP 5.5+ support.
+			if (is_string($file) && function_exists('curl_file_create')) {
+				$file = curl_file_create($file);
+			} else {
+				$file = '@' . $file;
+			}
+			$request['file'] = $file;
 		}
 
 		return (string)$this->putData($request)->result;


### PR DESCRIPTION
Adding `curl_file_create` support for PHP 5.5+ support. This is in the same vain as https://github.com/BrightcoveOS/PHP-MAPI-Wrapper/pull/27.